### PR TITLE
Fix #23553: When large amounts of data are loaded, shrinkwrap blocks ui when changing selection

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ import java.net.URL
 
 plugins {
     kotlin("jvm") version "1.4.10"
-    id("org.openstreetmap.josm").version("0.7.0")
+    id("org.openstreetmap.josm").version("0.8.2")
 }
 
 //archivesBaseName = "Shrinkwrap"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat May 30 23:42:09 CEST 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionSha256Sum=740c2e472ee4326c33bf75a5c9f5cd1e69ecf3f9b580f6e236c86d1f3d98cfac
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists


### PR DESCRIPTION
For further details, see https://josm.openstreetmap.de/ticket/23553 .